### PR TITLE
Enable "user profile" Role setting

### DIFF
--- a/formhub/preset/ehealth_production.py
+++ b/formhub/preset/ehealth_production.py
@@ -1,6 +1,12 @@
 # this system uses structured settings.py as defined in http://www.slideshare.net/jacobian/the-best-and-worst-of-django
 
-from formhub.settings import *
+try:
+    from ..settings import *
+except ImportError:
+    import sys, django
+    django.utils.six.reraise(RuntimeError, *sys.exc_info()[1:])  # use RuntimeError to extend the traceback
+except:
+    raise
 
 DEBUG = False  # this setting file will not work on "runserver" -- it needs a server for static files
 

--- a/main/admin.py
+++ b/main/admin.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+from main.models import UserProfile, MetaData
+
+class ProfAdmin(admin.ModelAdmin):
+    list_display = ('user', 'name', 'role')
+
+admin.site.register(UserProfile, ProfAdmin)
+
+class MDAdmin(admin.ModelAdmin):
+    list_display = ('xform', 'data_type', 'data_value', 'data_file_type')
+
+admin.site.register(MetaData, MDAdmin)

--- a/main/templates/people.html
+++ b/main/templates/people.html
@@ -27,14 +27,8 @@
         <td>{{ user.profile.name }}</td>
         <td>{{ user.profile.organization }}</td>
         <td>{% if user.profile.city %}{{ user.profile.city }},{% endif %} {% if user.profile.country %}{{user.profile.country}}{% endif %}</td>
-	<td>{{ user.date_joined|date:"F j, Y" }}</td>
-        <td data-username="{{user.username}}">
-          {% if profile.role == UserProfile.ROLES.ADMIN %}
-            {{ user.permissions_form.role }}
-          {% else %}
-            {{ user.profile.get_role_display }}
-          {% endif %}
-        </td>
+	    <td>{{ user.date_joined|date:"F j, Y" }}</td>
+        <td>{{ user.profile.get_role_display }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/main/views.py
+++ b/main/views.py
@@ -244,8 +244,11 @@ def members_list(request):
     users = User.objects.all()
     context.template = 'people.html'
     context.users = users
-    for user in context.users:
-        user.permissions_form = RoleForm(role=user.profile.role)
+    # for user in context.users:
+    #     try:
+    #         user.permissions_form = RoleForm(role=user.profile.role)
+    #     except User.DoesNotExist:
+    #         pass
     return render_to_response("people.html", context_instance=context)
 
 

--- a/odk_logger/admin.py
+++ b/odk_logger/admin.py
@@ -4,8 +4,7 @@ from odk_logger.models import XForm
 
 class FormAdmin(admin.ModelAdmin):
 
-    exclude = ('user',)
-    list_display = ('id_string', 'form_active', 'shared')
+    list_display = ('id_string', 'user', 'form_active', 'shared')
 
     # A user should only see forms that belong to him.
     def queryset(self, request):


### PR DESCRIPTION
sprint.ly issue #28 was caused by all users on the system having a "Viewer" role.  This enables django admin access to the User Profile table so that selected users can be set to "Admin".
