### PR TITLE
Feature/tim/fix 1137 settings file

### DIFF
--- a/formhub/settings.py
+++ b/formhub/settings.py
@@ -395,3 +395,12 @@ MONGO_DB = MONGO_CONNECTION[MONGO_DATABASE['NAME']]
 # this is rather pointless, currently, given the state of the tests
 # however, some functions require its being defined
 TESTING_MODE = False
+
+
+try:
+    from local_settings import *
+except ImportError as e:
+    import logging
+    import traceback
+    logging.warning('Could not import local_settings. Moving on... \n {e}'.format(e=e))
+

--- a/formhub/settings.py
+++ b/formhub/settings.py
@@ -401,6 +401,5 @@ try:
     from local_settings import *
 except ImportError as e:
     import logging
-    import traceback
     logging.warning('Could not import local_settings. Moving on... \n {e}'.format(e=e))
 


### PR DESCRIPTION
This PR will stop merge conflicts for production settings across installations
https://sprint.ly/product/22465/item/1137

UPDATE: starts usage of local_settings.py because remove the formhub/presets/production.py would cause problems if you were not expecting the file to be removed. This way we can start using serve specific settings without disrupting existing deployments.