### PR TITLE
Delay start of django app for mongodb

### DIFF
--- a/docker/files/docker-start.sh
+++ b/docker/files/docker-start.sh
@@ -3,6 +3,7 @@
 export DJANGO_SETTINGS_MODULE=formhub.preset.ehealth_docker
 
 sudo service mongodb start
+sleep 10
 sudo service postgresql start
 
 sudo -H -u postgres bash -c "createdb formhubdjangodb"


### PR DESCRIPTION
When running in daemon mode, the django app tries to connect to mongodb
before mongo is actually up and running.  This causes the start script
to end with a non-0 code and the container stops running.  To fix this,
delay the start of the django app by some arbitrary time to allow
mongodb to fully startup.
